### PR TITLE
Minor fixes, Tidy code to pass flake8, pylint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='pyvera',
-      version='0.2.6',
+      version='0.2.7',
       description='Python API for talking to Vera Z-Wave controllers',
       url='https://github.com/pavoni/pyvera',
       author='James Cole, Greg Dowling',


### PR DESCRIPTION
A small change to set local state when setting the Vera device.

Net effect is to set the device state as you expect (before a Vera update arrives if you're using subscriptions, or without doing a refresh if you're not).

A small breaking change related to category filters - you now have to pass a list (very easy even if you have a single item). Avoid a pylint error.

Also adds docstrings, now passes flake8 and pylint without warnings.

Closes https://github.com/pavoni/pyvera/issues/4