### PR TITLE
couldn't import VeraLock in subclass

### DIFF
--- a/pyvera/subscribe.py
+++ b/pyvera/subscribe.py
@@ -63,7 +63,8 @@ class SubscriptionRegistry(object):
         sending = comment.find('Sending') >= 0
         if sending and state == STATE_NO_JOB:
             state = STATE_JOB_WAITING_TO_START
-        if (state == STATE_JOB_IN_PROGRESS and isinstance(device, VeraLock)):
+        if (state == STATE_JOB_IN_PROGRESS and
+                device.__class__.__name__ == 'VeraLock'):
             # VeraLocks don't complete - so force state
             state = STATE_JOB_DONE
         if (

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='pyvera',
-      version='0.2.12',
+      version='0.2.13',
       description='Python API for talking to Vera Z-Wave controllers',
       url='https://github.com/pavoni/pyvera',
       author='James Cole, Greg Dowling',


### PR DESCRIPTION
This ughly hack should addres `16-07-01 13:19:29 pyvera.subscribe: Vera thread exception name 'VeraLock' is not defined`

You might want to just hotfix 0.2.12 instead, although I'm happy to send a MR to HA to bump the requirements to 0.2.13.