### PR TITLE
Add detection support for UI5 dimmers and locks (issue #24)

### DIFF
--- a/pyvera/__init__.py
+++ b/pyvera/__init__.py
@@ -152,7 +152,7 @@ class VeraController(object):
                   item.get('deviceInfo').get('categoryName') ==
                   'Door lock'):
                 doorlock = VeraLock(item, self)
-                doorlock.category = "Doorlock"
+                doorlock.category = 'Doorlock'
                 self.devices.append(doorlock)
             else:
                 self.devices.append(VeraDevice(item, self))

--- a/pyvera/__init__.py
+++ b/pyvera/__init__.py
@@ -115,8 +115,14 @@ class VeraController(object):
                 self.devices.append(VeraSwitch(item, self))
             elif (item.get('deviceInfo') and
                   item.get('deviceInfo').get('categoryName') ==
-                  'Dimmable Switch'):
+                  'Dimmable Switch'):        
                 self.devices.append(VeraDimmer(item, self))
+            elif (item.get('deviceInfo') and
+                  item.get('deviceInfo').get('categoryName') ==
+                  'Dimmable Light'):        
+                dimmer = VeraDimmer(item, self)
+                dimmer.category = "Dimmable Switch"
+                self.devices.append(dimmer)
             elif (item.get('deviceInfo') and
                   item.get('deviceInfo').get('categoryName') ==
                   'Temperature Sensor'):
@@ -142,6 +148,12 @@ class VeraController(object):
                   item.get('deviceInfo').get('categoryName') ==
                   'Doorlock'):
                 self.devices.append(VeraLock(item, self))
+            elif (item.get('deviceInfo') and
+                  item.get('deviceInfo').get('categoryName') ==
+                  'Door lock'):
+                doorlock = VeraLock(item, self)
+                doorlock.category = "Doorlock"
+                self.devices.append(doorlock)
             else:
                 self.devices.append(VeraDevice(item, self))
 
@@ -379,7 +391,7 @@ class VeraDevice(object):
     @property
     def is_dimmable(self):
         """Device is dimmable."""
-        return self.category == "Dimmable Switch"
+        return 'dimmable' in self.category.lower()
 
     @property
     def is_trippable(self):

--- a/pyvera/__init__.py
+++ b/pyvera/__init__.py
@@ -115,7 +115,7 @@ class VeraController(object):
                 self.devices.append(VeraSwitch(item, self))
             elif (item.get('deviceInfo') and
                   item.get('deviceInfo').get('categoryName') ==
-                  'Dimmable Switch'):        
+                  'Dimmable Switch'):
                 self.devices.append(VeraDimmer(item, self))
             elif (item.get('deviceInfo') and
                   item.get('deviceInfo').get('categoryName') ==


### PR DESCRIPTION
These changes allow detection of dimmers and locks from UI5 VeraLite and possibly other UI5 Vera controllers. No modifications to Home-Assistant's Vera component are required.
