### PR TITLE
Switch to use native 0-100 scale for curtain.

### DIFF
--- a/pyvera/__init__.py
+++ b/pyvera/__init__.py
@@ -610,29 +610,20 @@ class VeraCurtain(VeraSwitch):
 
         Refresh data from Vera if refresh is True, otherwise use local cache.
         Refresh is only needed if you're not using subscriptions.
-        Converts the Vera level property for curtains from a percentage to the
-        0 - 255 scale used by HA.
+        Scale is 0-100
         """
         if refresh:
             self.refresh()
-        value = 0
         level = self.get_value('level')
-        percent = 0 if level is None else int(level)
-        if percent > 0:
-            value = round(percent * 2.55)
-        return int(value)
+        return 0 if level is None else int(level)
 
     def set_level(self, level):
         """Set open level of the curtains.
 
-        Converts the Vera level property for curtains from a percentage to the
-        0 - 255 scale used by HA.
+        Scale is 0-100
         """
-        percent = 0
-        if level > 0:
-            percent = round(level / 2.55)
-        self.set_value('LoadLevelTarget', percent)
-        self.set_cache_value('level', percent)
+        self.set_value('LoadLevelTarget', level)
+        self.set_cache_value('level', level)
 
 
 class VeraLock(VeraDevice):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='pyvera',
-      version='0.2.17',
+      version='0.2.18',
       description='Python API for talking to Vera Z-Wave controllers',
       url='https://github.com/pavoni/pyvera',
       author='James Cole, Greg Dowling',


### PR DESCRIPTION
No point in converting to 0-255 for HA - and then converting back. 

However this is a breaking change for anyone else using the existing code when upgrading to 0.2.18 (cc @arjenfvellinga )

The same conversion for lights should really be done in the HA wrapper rather than the pyvera code. Will raise an issue.