### PR TITLE
Handle duplicate names

### DIFF
--- a/pyvera/__init__.py
+++ b/pyvera/__init__.py
@@ -228,7 +228,7 @@ class VeraDevice(object):
         if self.json_state.get('deviceInfo'):
             self.category = (
                 self.json_state.get('deviceInfo').get('categoryName'))
-            self.name = self.json_state.get('deviceInfo').get('name')
+            self.name = self.json_state.get('deviceInfo').get('name') + ' ' + str(self.device_id)
         else:
             self.category = ''
 


### PR DESCRIPTION
I have multiple ceiling lights in different rooms and therefor they are named the same (=Plafondlamp).

HASS maps the Vera devices to entities, but with each restart the mapping changes. So one time it is mapped like this:

```
light.plafondlamp_5	 - Vera Device Id: 66
friendly_name: Plafondlamp
```

and on the next restart it could be:

```
light.plafondlamp_5	 - Vera Device Id: 29
friendly_name: Plafondlamp
```

So with duplicate names grouping for instance is impossible. Adding the Vera `device_id` to the name, duplicate names are prevented.

Although I could manually change the device names in the Vera controller it is not obvious for new HASS users why entities changes with a restart.

I thought of sorting the devices in `get_devices` so the order is fixed and the mapping will always be the same. But that isn't true when a new device is added with a similar name.

I'm not sure this is the right way to go, but it solves my problem. But I thinks it will mess with the current users.