### PR TITLE
Temperatures now come back as floats instead of strings

### DIFF
--- a/pyvera/__init__.py
+++ b/pyvera/__init__.py
@@ -770,13 +770,13 @@ class VeraThermostat(VeraDevice):
         """Get current goal temperature / setpoint"""
         if refresh:
             self.refresh()
-        return self.get_value('setpoint')
+        return float(self.get_value('setpoint'))
 
     def get_current_temperature(self, refresh=False):
         """Get current temperature"""
         if refresh:
             self.refresh()
-        return self.get_value('temperature')
+        return float(self.get_value('temperature'))
 
     def set_hvac_mode(self, mode):
         """Set the hvac mode"""


### PR DESCRIPTION
Home Assistant gets confused when temperatures are returned as strings, this fixes it.