### PR TITLE
Fix user config error

### DIFF
--- a/pyvera/subscribe.py
+++ b/pyvera/subscribe.py
@@ -86,6 +86,8 @@ class SubscriptionRegistry(object):
         if not (state == STATE_JOB_DONE or
                 state == STATE_NOT_PRESENT or
                 state == STATE_NO_JOB or
+                (state == STATE_JOB_ERROR and 
+                comment.find('Setting user configuration'))):
             LOG.error("Device %s, state %s, %s",
                       device.name,
                       state,

--- a/pyvera/subscribe.py
+++ b/pyvera/subscribe.py
@@ -85,7 +85,7 @@ class SubscriptionRegistry(object):
             return
         if not (state == STATE_JOB_DONE or
                 state == STATE_NOT_PRESENT or
-                state == STATE_NO_JOB):
+                state == STATE_NO_JOB or
             LOG.error("Device %s, state %s, %s",
                       device.name,
                       state,


### PR DESCRIPTION
If a vera device is unable to set user configurations, it may still
report updated values correctly.

This PR will check if the state is error, and the comment contains the
"Setting user configuration" string, and if it does allow the state to
be updated for the device.

Fixes #66