### PR TITLE
Dont create an armable device if its already a switch

### DIFF
--- a/pyvera/__init__.py
+++ b/pyvera/__init__.py
@@ -148,7 +148,7 @@ class VeraController(object):
                 else:
                     device = VeraDevice(item, self)
                 self.devices.append(device)
-                if device.is_armable:
+                if device_category != CATEGORY_SWITCH and device.is_armable:
                     self.devices.append(VeraArmableDevice(item, self))
             else:
                 self.devices.append(VeraDevice(item, self))


### PR DESCRIPTION
This should resolve this issue:

https://community.home-assistant.io/t/entity-id-already-exists/30305

Where there is a switch thats also armable, so it ends up creating 2 switches in home assistant of the same name.  Looking back at the pre-category-id vera code, it didnt create an armable device for an on/off switch, so this should go back to that behavior.