### PR TITLE
Poll hardening

### DIFF
--- a/pyvera/subscribe.py
+++ b/pyvera/subscribe.py
@@ -24,7 +24,11 @@ STATE_NOT_PRESENT = 999
 
 LOG = logging.getLogger(__name__)
 
-
+class PyveraError(Exception):
+    def __init__(self, arg):
+        self.strerror = arg
+        self.args = {arg}
+    
 class SubscriptionRegistry(object):
     """Class for subscribing to wemo events."""
 
@@ -95,7 +99,15 @@ class SubscriptionRegistry(object):
             return
         device.update(device_data)
         for callback in self._callbacks.get(device, ()):
-            callback(device)
+            try:
+                callback(device)
+            except:
+                # (Very) broad check to not let loosely-implemented callbacks
+                # kill our polling thread. They should be catching their own
+                # errors, so if it gets back to us, just log it and move on.
+                LOG.exception(
+                    "Unhandled exception in callback for device #%s (%s)",
+                    str(device.device_id), device.name)
 
     def join(self):
         """Don't allow the main thread to terminate until we have."""
@@ -120,35 +132,31 @@ class SubscriptionRegistry(object):
         timestamp = None
         while not self._exiting:
             try:
+                LOG.debug("Polling for Vera changes")
                 device_data, timestamp = (
                     controller.get_changed_devices(timestamp))
-                LOG.debug("Poll returned")
-
-                if self._exiting:
-                    continue
-
-                if device_data:
-                    self._event(device_data)
-                else:
-                    LOG.debug("No changes in poll interval")
-
-                continue
-
             except requests.RequestException as ex:
                 LOG.debug("Caught RequestException: %s", str(ex))
                 pass
-
-            except json.decoder.JSONDecodeError as ex:
-                LOG.debug("Caught JSONDecodeError: %s", str(ex))
+            except PyveraError as ex:
+                LOG.debug("Non-fatal error in poll: %s", str(ex))
                 pass
-
             except Exception as ex:
                 LOG.exception("Vera poll thread general exception: %s", 
-                              str(ex))
-                # Don't raise. Stay in control
-                #raise
+                    str(ex))
+                raise
+            else:
+                LOG.debug("Poll returned")
+                if not self._exiting:
+                    if device_data:
+                        self._event(device_data)
+                    else:
+                        LOG.debug("No changes in poll interval")
+                    time.sleep(1)
+                   
+                continue
 
-            LOG.info("Could not contact Vera - will retry in %ss",
+            LOG.info("Could not poll Vera - will retry in %ss",
                      SUBSCRIPTION_RETRY)
             time.sleep(SUBSCRIPTION_RETRY)
 

--- a/pyvera/subscribe.py
+++ b/pyvera/subscribe.py
@@ -25,9 +25,7 @@ STATE_NOT_PRESENT = 999
 LOG = logging.getLogger(__name__)
 
 class PyveraError(Exception):
-    def __init__(self, arg):
-        self.strerror = arg
-        self.args = {arg}
+    pass
     
 class SubscriptionRegistry(object):
     """Class for subscribing to wemo events."""


### PR DESCRIPTION
Harden the polling loop by checking the request Response object in some detail to detect various anomalies that can occur during Vera luup reloads. Since not all JSON implementations stick to de-factos for exception handling, and the requests module returns no error on disconnect with no data, widen the net for catching problems and handle them within a smaller subset of exceptions the polling thread and other callers can manage. Streamline the polling thread code itself just a bit, and add some logging in a few places where it may help to address future issues.