### PR TITLE
Additional fix to poll hardening to improve data sync

### DIFF
--- a/pyvera/__init__.py
+++ b/pyvera/__init__.py
@@ -243,20 +243,20 @@ class VeraController(object):
         payload.update({
             'id': 'lu_sdata',
         })
-        
+
         LOG.debug("get_changed_devices() requesting payload %s", str(payload))
         r = self.data_request(payload, TIMEOUT*2)
         r.raise_for_status()
 
-        # If the Vera disconnects before writing a full response (as lu_sdata 
-        # will do when interrupted by a Luup reload), the requests module will 
+        # If the Vera disconnects before writing a full response (as lu_sdata
+        # will do when interrupted by a Luup reload), the requests module will
         # happily return 200 with an empty string. So, test for empty response,
         # so we don't rely on the JSON parser to throw an exception.
         if r.text == "":
             raise PyveraError("Empty response from Vera")
-            
+
         # Catch a wide swath of what the JSON parser might throw, within
-        # reason. Unfortunately, some parsers don't specifically return 
+        # reason. Unfortunately, some parsers don't specifically return
         # json.decode.JSONDecodeError, but so far most seem to derive what
         # they do throw from ValueError, so that's helpful.
         try:
@@ -264,10 +264,10 @@ class VeraController(object):
         except ValueError as ex:
             raise PyveraError("JSON decode error: " + str(ex))
 
-        if not ( type(result) is dict 
+        if not ( type(result) is dict
                  and 'loadtime' in result and 'dataversion' in result ):
             raise PyveraError("Unexpected/garbled response from Vera")
-            
+
         # At this point, all good. Update timestamp and return change data.
         device_data = result.get('devices')
         timestamp = {

--- a/pyvera/subscribe.py
+++ b/pyvera/subscribe.py
@@ -26,7 +26,7 @@ LOG = logging.getLogger(__name__)
 
 class PyveraError(Exception):
     pass
-    
+
 class SubscriptionRegistry(object):
     """Class for subscribing to wemo events."""
 
@@ -140,7 +140,7 @@ class SubscriptionRegistry(object):
                 LOG.debug("Non-fatal error in poll: %s", str(ex))
                 pass
             except Exception as ex:
-                LOG.exception("Vera poll thread general exception: %s", 
+                LOG.exception("Vera poll thread general exception: %s",
                     str(ex))
                 raise
             else:
@@ -151,9 +151,11 @@ class SubscriptionRegistry(object):
                     else:
                         LOG.debug("No changes in poll interval")
                     time.sleep(1)
-                   
+
                 continue
 
+            # After error, discard timestamp for fresh update.
+            timestamp = None
             LOG.info("Could not poll Vera - will retry in %ss",
                      SUBSCRIPTION_RETRY)
             time.sleep(SUBSCRIPTION_RETRY)

--- a/pyvera/subscribe.py
+++ b/pyvera/subscribe.py
@@ -154,7 +154,7 @@ class SubscriptionRegistry(object):
 
                 continue
 
-            # After error, discard timestamp for fresh update.
+            # After error, discard timestamp for fresh update. pyvera issue #89
             timestamp = None
             LOG.info("Could not poll Vera - will retry in %ss",
                      SUBSCRIPTION_RETRY)


### PR DESCRIPTION
As mentioned in issue #89 , Vera gives inaccurate results across Luup reloads if the timestamp parameters (loadtime and dataversion) are used spanning the reload. That is, if a reload occurs, and Vera is then presented with a dataversion from before the reload, it will give inaccurate deltas not just to the initial call, but to subsequent calls as well. Resetting the timestamp on an exception (usually a RequestException resulting from Vera being unreachable during its reload) forces the next long pull to return a full data set, resyncing the local data and providing a stable dataversion with which to continue.