### PR TITLE
Correct VeraLock status while in progress

### DIFF
--- a/examples/lock-all-doors-with-status.py
+++ b/examples/lock-all-doors-with-status.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+# Import project path
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
+
+# Import pyvera
+import pyvera
+
+import time
+
+# Parse Arguments
+import argparse
+parser = argparse.ArgumentParser(description='lock-all-doors-with-status')
+parser.add_argument('-u', '--url', help="Vera URL, e.g. http://192.168.1.161:3480", required=True)
+args = parser.parse_args()
+
+# Define a callback that runs each time a device changes state
+def device_info_callback(vera_device):
+    # Do what we want with the changed device information
+    print('{}_{}: locked={}'.format(vera_device.name, vera_device.device_id, vera_device.is_locked()))
+
+# Start the controller
+controller, _ = pyvera.init_controller(args.url)
+
+try:
+    # Get a list of all the devices on the vera controller
+    all_devices = controller.get_devices()
+
+    # Look over the list and find the lock devices
+    lock_devices = []
+    for device in all_devices:
+        if isinstance(device, pyvera.VeraLock):
+            # Register a callback that runs when the info for that device is updated
+            controller.register(device, device_info_callback)
+            print('Initially, {}_{}: locked={}'.format(device.name, device.device_id, device.is_locked()))
+            lock_devices.append(device)
+            if not device.is_locked():
+                device.lock()
+
+    # Loop until someone hits Ctrl-C to interrupt the listener
+    try:
+        all_locked = False
+        while not all_locked:
+            time.sleep(1)
+            all_locked = True
+            for device in lock_devices:
+                if not device.is_locked():
+                    all_locked = False
+        print('All doors are now locked')
+
+    except KeyboardInterrupt:
+        print('Got interrupted by user')
+        pass
+
+    # Unregister our callback
+    for device in lock_devices:
+        controller.unregister(device, device_info_callback)
+
+finally:
+    # Stop the subscription listening thread so we can quit
+    controller.stop()
+

--- a/pyvera/__init__.py
+++ b/pyvera/__init__.py
@@ -8,7 +8,6 @@ import requests
 import sys
 import json
 import os
-import threading
 
 from .subscribe import SubscriptionRegistry
 from .subscribe import PyveraError
@@ -21,8 +20,6 @@ SUBSCRIPTION_WAIT = 30
 SUBSCRIPTION_MIN_WAIT = 200
 # Timeout for requests calls, as vera sometimes just sits on sockets.
 TIMEOUT = SUBSCRIPTION_WAIT
-# VeraLock set target timeout in seconds
-LOCK_TARGET_TIMEOUT = 30
 
 CATEGORY_DIMMER = 2
 CATEGORY_SWITCH = 3

--- a/pyvera/__init__.py
+++ b/pyvera/__init__.py
@@ -181,7 +181,7 @@ class VeraController(object):
         # pylint: disable=too-many-branches
 
         # the Vera rest API is a bit rough so we need to make 2 calls to get
-        # all the info e need
+        # all the info we need
         self.get_simple_devices_info()
 
         j = self.data_request({'id': 'status', 'output_format': 'json'}).json()
@@ -480,7 +480,7 @@ class VeraDevice(object):  # pylint: disable=R0904
         """Set a variable in the local state dictionary.
 
         This does not change the physical device. Useful if you want the
-        device state to refect a new value which has not yet updated drom
+        device state to refect a new value which has not yet updated from
         Vera.
         """
         dev_info = self.json_state.get('deviceInfo')
@@ -933,12 +933,6 @@ class VeraCurtain(VeraSwitch):
 class VeraLock(VeraDevice):
     """Class to represent a door lock."""
 
-    # target locked state
-    # this is used since sdata does not return proper job status for locks
-    lock_target = None
-    # target locked state fallback timer
-    lock_target_timer = None
-
     def set_lock_state(self, state):
         """Set the lock state, also update local state."""
         self.set_service_value(
@@ -946,39 +940,7 @@ class VeraLock(VeraDevice):
             'Target',
             'newTargetValue',
             state)
-        #TODO should we set the cache and assume lock will complete later?
-        #self.set_cache_value('locked', state)
-        self.finish_last_target_lock()
-        self.start_target_lock(state)
-
-    def start_target_lock(self, state):
-        """Starts a lock timer for a target."""
-        logger.debug('Watching for a new lock target: {}'.format(state))
-        self.lock_target = state
-        self.lock_target_timer = threading.Timer(LOCK_TARGET_TIMEOUT, self.resolve_target_state)
-        self.lock_target_timer.start()
-
-    def finish_last_target_lock(self):
-        """Cancels the lock timer and resets lock progress."""
-        logger.debug('Done with lock target: {}'.format(self.lock_target))
-        self.lock_target = None
-        if self.lock_target_timer:
-            self.lock_target_timer.cancel()
-        self.lock_target_timer = None
-
-    def resolve_target_state(self):
-        """Callback to run if we timeout trying to lock."""
-        logger.error('Timeout reached waiting lock to complete, timeout={}s'.format(LOCK_TARGET_TIMEOUT))
-        self.lock_target = None
-
-    def lock_progress_complete(self, device_data):
-        """Checks to see if we have a lock in progress."""
-        if self.lock_target is not None:
-            if int(self.lock_target) == int(device_data.get('locked')):
-                self.finish_last_target_lock()
-                return True
-            return False
-        return True
+        self.set_cache_value('locked', state)
 
     def lock(self):
         """Lock the door."""

--- a/pyvera/subscribe.py
+++ b/pyvera/subscribe.py
@@ -120,7 +120,6 @@ class SubscriptionRegistry(object):
                       state,
                       comment)
             return
-        logger.debug('########################################Updating {}: {}'.format(device.name, device_data))
         device.update(device_data)
         for callback in self._callbacks.get(device, ()):
             try:

--- a/pyvera/subscribe.py
+++ b/pyvera/subscribe.py
@@ -76,8 +76,13 @@ class SubscriptionRegistry(object):
             state = STATE_JOB_WAITING_TO_START
         if (state == STATE_JOB_IN_PROGRESS and
                 device.__class__.__name__ == 'VeraLock'):
-            # VeraLocks don't complete - so force state
+            # VeraLocks don't complete locking - so detect if we are done
             state = STATE_JOB_DONE
+            # prevent updates if we are still trying to lock
+            if not device.lock_progress_complete(device_data):
+                LOG.debug('Lock still in progress')
+                state = STATE_JOB_IN_PROGRESS
+
         if (
                 state == STATE_JOB_WAITING_TO_START or
                 state == STATE_JOB_IN_PROGRESS or

--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,5 @@ setup(name='pyvera',
       license='MIT',
       install_requires=['requests>=2.0'],
       packages=find_packages(),
+      test_suite="tests",
       zip_safe=True)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,37 @@
+import unittest
+import mock
+import json
+import logging
+
+import sys
+import os
+sys.path.insert(0, os.path.abspath('..'))
+import pyvera
+
+#pyvera.logger = mock.create_autospec(logging.Logger)
+logging.basicConfig(level=logging.DEBUG)
+pyvera.logger = logging.getLogger(__name__)
+
+class TestVeraLock(unittest.TestCase):
+    def test_set_lock_state(self):
+
+        mock_controller = mock.create_autospec(pyvera.VeraController)
+        status_json = json.loads(
+                '{'
+                '  "id": 33,'
+                '  "deviceInfo": {'
+                     # pyvera.CATEGORY_LOCK
+                '    "category": 7,'
+                '    "categoryName": "Doorlock",'
+                '    "name": "MyTestDeadbolt",'
+                '    "locked": 0'
+                '  }'
+                '}'
+                )
+        lock = pyvera.VeraLock(status_json, mock_controller)
+        lock.set_lock_state(1)
+        self.assertTrue(lock.get_value('locked'), '1')
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/subscribe.py
+++ b/tests/subscribe.py
@@ -1,0 +1,84 @@
+import unittest
+import mock
+import json
+import logging
+
+import sys
+import os
+sys.path.insert(0, os.path.abspath('..'))
+import pyvera
+
+#pyvera.logger = mock.create_autospec(logging.Logger)
+logging.basicConfig(level=logging.DEBUG)
+pyvera.logger = logging.getLogger(__name__)
+
+class TestSubscriptionRegistry(unittest.TestCase):
+    def test__event_device_for_vera_lock_status(self):
+
+        sr = pyvera.SubscriptionRegistry()
+        mock_lock = mock.create_autospec(pyvera.VeraLock)
+        mock_lock.name = mock.MagicMock(return_value='MyTestDeadbolt')
+
+        # Deadbolt changing but not done
+        device_json = json.loads(
+                '{'
+                   # subscribe.STATE_JOB_IN_PROGRESS
+                '  "state": "1"'
+                '}'
+                )
+        sr._event_device(mock_lock, device_json)
+        mock_lock.update.assert_not_called()
+
+        # Deadbolt progress with reset state but not done
+        device_json = json.loads(
+                '{'
+                   # subscribe.STATE_NO_JOB
+                '  "state": "-1",'
+                '  "comment": "MyTestDeadbolt: Sending the Z-Wave command after 0 retries"'
+                '}'
+                )
+        sr._event_device(mock_lock, device_json)
+        mock_lock.update.assert_not_called()
+
+        # Deadbolt progress locked but not done
+        device_json = json.loads(
+                '{'
+                   # subscribe.STATE_JOB_IN_PROGRESS
+                '  "state": "1",'
+                '  "locked": "1",'
+                '  "comment": "MyTestDeadbolt"'
+                '}'
+                )
+        sr._event_device(mock_lock, device_json)
+        mock_lock.update.assert_not_called()
+
+        # Deadbolt progress with status but not done
+        device_json = json.loads(
+                '{'
+                   # subscribe.STATE_JOB_IN_PROGRESS
+                '  "state": "1",'
+                '  "comment": "MyTestDeadbolt: Please wait! Polling node"'
+                '}'
+                )
+        sr._event_device(mock_lock, device_json)
+        mock_lock.update.assert_not_called()
+
+        # Deadbolt progress complete
+        device_json = json.loads(
+                '{'
+                   # subscribe.STATE_JOB_IN_PROGRESS
+                '  "state": "1",'
+                '  "locked": "1",'
+                '  "comment": "MyTestDeadbolt: SUCCESS! Successfully polled node",'
+                '  "deviceInfo": {'
+                     # pyvera.CATEGORY_LOCK
+                '    "category": 7'
+                '  }'
+                '}'
+                )
+        sr._event_device(mock_lock, device_json)
+        mock_lock.update.assert_called_once_with(device_json)
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Modify VeraLock to correct the progress sdata problem so that it will wait before giving back lock status until it has completed un/locking, also provided another example for sending a command to lock all VeraLocks