### PR TITLE
fix logger so that HomeAssistant can pass logging on to pyvera

### DIFF
--- a/pyvera/__init__.py
+++ b/pyvera/__init__.py
@@ -42,10 +42,12 @@ _VERA_CONTROLLER = None
 logger = logging.getLogger(__name__)
 # Set logging level (such as INFO, DEBUG, etc) via an environment variable
 # Defaults to WARNING log level unless PYVERA_LOGLEVEL variable exists
-logger.setLevel(os.environ.get("PYVERA_LOGLEVEL", "WARNING"))
-ch = logging.StreamHandler()
-ch.setFormatter(logging.Formatter('%(levelname)s@{%(name)s:%(lineno)d} - %(message)s'))
-logger.addHandler(ch)
+logger_level = os.environ.get("PYVERA_LOGLEVEL", None)
+if logger_level:
+    logger.setLevel(logger_level)
+    ch = logging.StreamHandler()
+    ch.setFormatter(logging.Formatter('%(levelname)s@{%(name)s:%(lineno)d} - %(message)s'))
+    logger.addHandler(ch)
 logger.debug("DEBUG logging is ON")
 
 def init_controller(url):


### PR DESCRIPTION
After you pointed out that HA can also enable logging, as in adding this to configuration.yaml:
~~~~
logger:
  logs:
      pyvera: debug
~~~~
I realized I messed that ability up with my last pull request, please merge this one to fix the problem I introduced.  Thanks

