### PR TITLE
Don't consider a curtain as armable

### DIFF
--- a/pyvera/__init__.py
+++ b/pyvera/__init__.py
@@ -223,6 +223,7 @@ class VeraController(object):
                 if (device.is_armable and not (
                     device_category == CATEGORY_SWITCH or
                     device_category == CATEGORY_VERA_SIREN or
+                    device_category == CATEGORY_CURTAIN or
                     device_category == CATEGORY_GARAGE_DOOR)):
                     self.devices.append(VeraArmableDevice(item, self))
             else:


### PR DESCRIPTION
For some reason my vera reports 2 of my covers as armable.
Obviously this is wrong, besides the cover it creates a switch in homeassistant with the same device id.