### PR TITLE
Guard against null or missing values

### DIFF
--- a/pyvera/__init__.py
+++ b/pyvera/__init__.py
@@ -326,10 +326,10 @@ class VeraController(object):
             raise PyveraError("Unexpected/garbled response from Vera")
 
         # At this point, all good. Update timestamp and return change data.
-        device_data = result.get('devices')
+        device_data = result.get('devices', [])
         timestamp = {
-            'loadtime': result.get('loadtime'),
-            'dataversion': result.get('dataversion')
+            'loadtime': result.get('loadtime', 0),
+            'dataversion': result.get('dataversion', 1)
         }
         return [device_data, timestamp]
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='pyvera',
-      version='0.3.1',
+      version='0.3.2',
       description='Python API for talking to Vera Z-Wave controllers',
       url='https://github.com/pavoni/pyvera',
       author='James Cole, Greg Dowling',


### PR DESCRIPTION
After running for a bit, discovered an issue where the 'devices' key was missing from the returned JSON. This wasn't something I'd ran into while testing, but this should prevent exceptions when it happens.