### PR TITLE
Fix for: https://github.com/home-assistant/home-assistant/issues/24987

### DIFF
--- a/pyvera/subscribe.py
+++ b/pyvera/subscribe.py
@@ -95,7 +95,7 @@ class SubscriptionRegistry(object):
 
         for device_id in device_ids:
             try:
-                device_list = self._devices.get(device_id, ())
+                device_list = self._devices.get(int(device_id), ())
                 device_datas = [data for data in device_data_list if data.get('id') == device_id]
                 device_alerts = [alert for alert in device_alert_list if alert.get('PK_Device') == device_id]
 


### PR DESCRIPTION
because device_id is a string and the keys in _self.devices are integers...

Maybe some other code should be changed so the types match, but this fixes the issue.
Now the device_list is populated (is it really a list, it's always just one device, or am I missing something? )