### PR TITLE
Support for more than 1 controller

### DIFF
--- a/pyvera/__init__.py
+++ b/pyvera/__init__.py
@@ -96,7 +96,7 @@ class VeraController(object):
         self.model = None
         self.serial_number = None
         self.device_services_map = None
-        self.subscription_registry = SubscriptionRegistry()
+        self.subscription_registry = SubscriptionRegistry(self)
         self.categories = {}
         self.device_id_map = {}
 

--- a/pyvera/subscribe.py
+++ b/pyvera/subscribe.py
@@ -33,12 +33,13 @@ class PyveraError(Exception):
 class SubscriptionRegistry(object):
     """Class for subscribing to wemo events."""
 
-    def __init__(self):
+    def __init__(self, controller=None):
         """Setup subscription."""
         self._devices = collections.defaultdict(list)
         self._callbacks = collections.defaultdict(list)
         self._exiting = False
         self._poll_thread = None
+        self._controller = controller
 
     def register(self, device, callback):
         """Register a callback.
@@ -179,7 +180,7 @@ class SubscriptionRegistry(object):
 
     def _run_poll_server(self):
         from pyvera import get_controller
-        controller = get_controller()
+        controller = self._controller or get_controller()
         timestamp = {'dataversion': 1, 'loadtime': 0}
         device_data = []
         alert_data = []

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(name='pyvera',
       author_email='mail@gregdowling.com',
       license='MIT',
       install_requires=['requests>=2.0'],
+      tests_require=['mock'],
       packages=find_packages(),
       test_suite="tests",
       zip_safe=True)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -28,7 +28,7 @@ class TestVeraLock(unittest.TestCase):
                 '  }'
                 '}'
                 )
-        lock = pyvera.VeraLock(status_json, mock_controller)
+        lock = pyvera.VeraLock(status_json, [], mock_controller)
         lock.set_lock_state(1)
         self.assertTrue(lock.get_value('locked'), '1')
 

--- a/tests/subscribe.py
+++ b/tests/subscribe.py
@@ -26,7 +26,7 @@ class TestSubscriptionRegistry(unittest.TestCase):
                 '  "state": "1"'
                 '}'
                 )
-        sr._event_device(mock_lock, device_json)
+        sr._event_device(mock_lock, device_json, [])
         mock_lock.update.assert_not_called()
 
         # Deadbolt progress with reset state but not done
@@ -37,7 +37,7 @@ class TestSubscriptionRegistry(unittest.TestCase):
                 '  "comment": "MyTestDeadbolt: Sending the Z-Wave command after 0 retries"'
                 '}'
                 )
-        sr._event_device(mock_lock, device_json)
+        sr._event_device(mock_lock, device_json, [])
         mock_lock.update.assert_not_called()
 
         # Deadbolt progress locked but not done
@@ -49,7 +49,7 @@ class TestSubscriptionRegistry(unittest.TestCase):
                 '  "comment": "MyTestDeadbolt"'
                 '}'
                 )
-        sr._event_device(mock_lock, device_json)
+        sr._event_device(mock_lock, device_json, [])
         mock_lock.update.assert_not_called()
 
         # Deadbolt progress with status but not done
@@ -60,7 +60,7 @@ class TestSubscriptionRegistry(unittest.TestCase):
                 '  "comment": "MyTestDeadbolt: Please wait! Polling node"'
                 '}'
                 )
-        sr._event_device(mock_lock, device_json)
+        sr._event_device(mock_lock, device_json, [])
         mock_lock.update.assert_not_called()
 
         # Deadbolt progress complete
@@ -76,7 +76,7 @@ class TestSubscriptionRegistry(unittest.TestCase):
                 '  }'
                 '}'
                 )
-        sr._event_device(mock_lock, device_json)
+        sr._event_device(mock_lock, device_json, [])
         mock_lock.update.assert_called_once_with(device_json)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Making code run in less of a singleton way by allowing a subscription to use an instance of a controller.
Fixing tests as they were broken.