### PR TITLE
Add ability for HASS to determine when user enters a valid PIN on lock

### DIFF
--- a/pyvera/__init__.py
+++ b/pyvera/__init__.py
@@ -84,6 +84,8 @@ class VeraController(object):
     # pylint: disable=too-many-instance-attributes
     temperature_units = 'C'
 
+    TIMESTAMP_NONE = {'dataversion': 1, 'loadtime': 0}
+
     def __init__(self, base_url):
         """Setup Vera controller at the given URL.
 
@@ -291,7 +293,11 @@ class VeraController(object):
     def get_changed_devices(self, timestamp):
         """Get data since last timestamp.
 
-        This is done via a blocking call, pass NONE for initial state.
+        This function blocks until a change is returned by the Vera, or the
+        request times out.
+
+        timestamp param: the timestamp returned by the last invocation of this
+        function.  Use a timestamp of TIMESTAMP_NONE for the first invocation.
         """
         payload = {
             'timeout': SUBSCRIPTION_WAIT,
@@ -335,7 +341,14 @@ class VeraController(object):
         return [device_data, timestamp]
 
     def get_alerts(self, timestamp):
-        """Get alerts that have triggered since last timestamp"""
+        """Get alerts that have triggered since last timestamp.
+
+        Note that unlike get_changed_devices, this is non-blocking.
+
+        timestamp param: the timestamp returned by the prior (not current)
+        invocation of get_changed_devices.  Use a timestamp of TIMESTAMP_NONE
+        for the first invocation.
+        """
 
         payload = {
             'LoadTime': timestamp['loadtime'],

--- a/pyvera/subscribe.py
+++ b/pyvera/subscribe.py
@@ -180,8 +180,9 @@ class SubscriptionRegistry(object):
 
     def _run_poll_server(self):
         from pyvera import get_controller
+        from pyvera import VeraController
         controller = self._controller or get_controller()
-        timestamp = {'dataversion': 1, 'loadtime': 0}
+        timestamp = VeraController.TIMESTAMP_NONE
         device_data = []
         alert_data = []
         data_changed = False


### PR DESCRIPTION
I really wanted Home Assistant to be able to take an action when I unlock my door with a valid PIN.  But the pyvera library didn't seem to give me the ability to do that in a clean way (and honestly, the Vera HTTP API makes it crazily complex to detect this event....).

So I created a function which makes this information to Home Assistant.  I also added a bunch of comments clarifying what I learned as I read the code.  Please let me know if you'd like anything here changed!