### PR TITLE
Making subscription shutdown more responsive. 

### DIFF
--- a/pyvera/subscribe.py
+++ b/pyvera/subscribe.py
@@ -7,7 +7,7 @@ import threading
 import requests
 
 # How long to wait before retrying Vera
-SUBSCRIPTION_RETRY = 10
+SUBSCRIPTION_RETRY = 9
 
 # Vera state codes see http://wiki.micasaverde.com/index.php/Luup_Requests
 STATE_NO_JOB = -1
@@ -187,7 +187,7 @@ class SubscriptionRegistry(object):
         device_data = []
         alert_data = []
         data_changed = False
-        while not self._exiting.wait(timeout=SUBSCRIPTION_RETRY):
+        while not self._exiting.wait(timeout=1):
             try:
                 logger.debug("Polling for Vera changes")
                 device_data, new_timestamp = (
@@ -221,5 +221,7 @@ class SubscriptionRegistry(object):
             timestamp = {'dataversion': 1, 'loadtime': 0}
             logger.info("Could not poll Vera - will retry in %ss",
                         SUBSCRIPTION_RETRY)
+
+            self._exiting.wait(timeout=SUBSCRIPTION_RETRY)
 
         logger.info("Shutdown Vera Poll Thread")

--- a/pyvera/subscribe.py
+++ b/pyvera/subscribe.py
@@ -37,7 +37,7 @@ class SubscriptionRegistry(object):
         """Setup subscription."""
         self._devices = collections.defaultdict(list)
         self._callbacks = collections.defaultdict(list)
-        self._exiting = False
+        self._exiting = None
         self._poll_thread = None
         self._controller = controller
 
@@ -175,7 +175,7 @@ class SubscriptionRegistry(object):
 
     def stop(self):
         """Tell the subscription thread to terminate."""
-        self._exiting.set()
+        self._exiting and self._exiting.set()
         self.join()
         logger.info("Terminated thread")
 


### PR DESCRIPTION
This should fix test timeout issues in https://github.com/home-assistant/home-assistant/pull/28340

Using thread events instead of time.sleep() for the loop to ensure the loop ends almost immediately after calling stop().