### PR TITLE
Manually specify response encoding

### DIFF
--- a/pyvera/__init__.py
+++ b/pyvera/__init__.py
@@ -119,7 +119,7 @@ class VeraController:
         """Perform a data_request and return the result."""
         request_url = self.base_url + "/data_request"
         response = requests.get(request_url, timeout=timeout, params=payload)
-        response.encoding = "utf-8"
+        response.encoding = response.encoding if response.encoding else "utf-8"
         return response
 
     def get_simple_devices_info(self) -> None:

--- a/pyvera/__init__.py
+++ b/pyvera/__init__.py
@@ -118,7 +118,9 @@ class VeraController:
     def data_request(self, payload: dict, timeout: int = TIMEOUT) -> requests.Response:
         """Perform a data_request and return the result."""
         request_url = self.base_url + "/data_request"
-        return requests.get(request_url, timeout=timeout, params=payload)
+        response = requests.get(request_url, timeout=timeout, params=payload)
+        response.encoding = "utf-8"
+        return response
 
     def get_simple_devices_info(self) -> None:
         """Get basic device info from Vera."""


### PR DESCRIPTION
Manually specify response encoding to avoid slowness caused by the chardet library when requests try to detect the encoding.

Documented here:
https://github.com/home-assistant/core/issues/32876

Basically, the vera device does not include a character encoding when responding to calls. When `requests` sees no character encoding, `requests` uses the `chardet` to detect the character encoding based on the raw bytes returned. As documented in the home assistant issue, this is an intensive process. To avoid this issue, we are manually setting the encoding to `utf-8`. This will prevent requests from using chardet.
