### PR TITLE
Fix VeraLock#set_new_pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,19 @@ If you have locks - this will show you information about them.
 $ ./examples/show_lock_info.py -u http://192.168.1.161:3480/
 ~~~~
 
-Set a new door lock code
+View existing locks and PINs:
 ~~~~
-$ ./examples/set_door_code.py -u http://192.168.1.161:3480/ -n "John Doe" -p "12345678"
+$ ./examples/show_lock_info.py -u http://192.168.1.161:3480/
 ~~~~
 
-Clear a existing door lock code
+Set a new door lock code on device 335:
 ~~~~
-$ ./examples/delete_door_code.py -u http://192.168.1.161:3480/ -n "John Doe" -p "12345678"
+$ ./examples/set_door_code.py -u http://192.168.1.161:3480/ -i 335 -n "John Doe" -p "5678"
+~~~~
+
+Clear a existing door lock code from device 335:
+~~~~
+$ ./examples/delete_door_code.py -u http://192.168.1.161:3480/ -i 335 -n "John Doe"
 ~~~~
 
 Debugging

--- a/examples/delete_door_code.py
+++ b/examples/delete_door_code.py
@@ -19,8 +19,8 @@ def main() -> None:
     parser.add_argument(
         "-u", "--url", help="Vera URL, e.g. http://192.168.1.161:3480;", required=True
     )
-    parser.add_argument("-n", "--name", 'Name eg: "John Doe"', required=True)
-    parser.add_argument("-s", "--slot", help='Slot eg: "4"', required=True)
+    parser.add_argument("-n", "--name", help='Name eg: "John Doe"', required=True)
+    parser.add_argument("-i", "--id", help='Device ID: "123"', required=True)
     args = parser.parse_args()
 
     # Start the controller
@@ -28,25 +28,25 @@ def main() -> None:
     controller.start()
 
     try:
-        # Get a list of all the devices on the vera controller
-        all_devices = controller.get_devices("Doorlock")
+        device = controller.get_device_by_id(int(args.id))
 
-        # Look over the list and find the lock devices
-        for device in all_devices:
-            if isinstance(device, VeraLock):
-
-                # You can only delete the slots on the lock
-                # You should also know which slot number you want to delete as an integer
-                # You can lookup name and slots using device.get_pin_codes() api
-                # This example deletes a previously added slot by getting the no:of slots already allocated
-                result = device.clear_slot_pin(slot=args.slot)
-                if result.status_code == 200:
-                    print(
-                        "\nCommand succesfully sent to Lock \
-                    \nWait for the lock to process the request"
-                    )
-                else:
-                    print("\nLock command " + result.text)
+        if isinstance(device, VeraLock):
+            pins = device.get_pin_codes()
+            found_slot = None
+            for slot, name, _ in pins:
+                if name == args.name:
+                    found_slot = slot
+            if found_slot is None:
+                print("No matching slot found\n")
+                return
+            result = device.clear_slot_pin(slot=int(found_slot))
+            if result.status_code == 200:
+                print(
+                    "\nCommand succesfully sent to Lock \
+                \nWait for the lock to process the request"
+                )
+            else:
+                print("\nLock command " + result.text)
 
     finally:
         # Stop the subscription listening thread so we can quit

--- a/examples/set_door_code.py
+++ b/examples/set_door_code.py
@@ -20,7 +20,8 @@ def main() -> None:
         "-u", "--url", help="Vera URL, e.g. http://192.168.1.161:3480;", required=True
     )
     parser.add_argument("-n", "--name", help='Name eg: "John Doe"', required=True)
-    parser.add_argument("-p", "--pin", help='Pin eg: "12345678"', required=True)
+    parser.add_argument("-p", "--pin", help='Pin eg: "5678"', required=True)
+    parser.add_argument("-i", "--id", help='Device ID: "123"', required=True)
     args = parser.parse_args()
 
     # Start the controller
@@ -28,28 +29,25 @@ def main() -> None:
     controller.start()
 
     try:
-        # Get a list of all the devices on the vera controller
-        all_devices = controller.get_devices("Doorlock")
+        device = controller.get_device_by_id(int(args.id))
 
-        # Look over the list and find the lock devices
-        for device in all_devices:
-            if isinstance(device, VeraLock):
-                # show exisiting door codes
-                print("Existing door codes:\n {}".format(device.get_pin_codes()))
+        if isinstance(device, VeraLock):
+            # show exisiting door codes
+            print("Existing door codes:\n {}".format(device.get_pin_codes()))
 
-                # set a new door code
-                result = device.set_new_pin(name=args.name, pin=args.pin)
+            # set a new door code
+            result = device.set_new_pin(name=args.name, pin=args.pin)
 
-                # printing the status code and error if any for debug logs
-                # print("status:"+str(result.status_code), result.text)
+            # printing the status code and error if any for debug logs
+            # print("status:"+str(result.status_code), result.text)
 
-                if result.status_code == 200:
-                    print(
-                        "\nCommand succesfully sent to Lock \
-                    \nWait for the lock to process the request"
-                    )
-                else:
-                    print("\nLock command " + result.text)
+            if result.status_code == 200:
+                print(
+                    "\nCommand succesfully sent to Lock \
+                \nWait for the lock to process the request"
+                )
+            else:
+                print("\nLock command " + result.text)
     finally:
         # Stop the subscription listening thread so we can quit
         controller.stop()

--- a/pyvera/__init__.py
+++ b/pyvera/__init__.py
@@ -1060,7 +1060,7 @@ class VeraLock(VeraDevice):
     def set_new_pin(self, name: str, pin: int) -> requests.Response:
         """Set the lock state, also update local state."""
         return self.set_door_code_values(
-            self.lock_service, "SetPin", {"UserCodeName": name, "Pin": pin}
+            self.lock_service, "SetPin", {"UserCodeName": name, "newPin": pin}
         )
 
     def clear_slot_pin(self, slot: int) -> requests.Response:


### PR DESCRIPTION
This PR updates the parameter used in the `SetPin` Vera call to use the `newPin` parameter, which matches what I see [documented](http://wiki.micasaverde.com/index.php/Luup_UPnP_Variables_and_Actions#DoorLock1) and what I am able to observe by making a similar change in the Vera UI and observing traffic via the web inspector.

Before this change, I received an error when running the included `set_door_code.py` example:

```
Lock command ERROR: The PIN entered is too long or short. Please enter a PIN of the specified length.
```

After this change I'm able to successfully set a PIN code on one of my locks.

In support of testing this change, I updated the included examples that set/delete PIN codes to require a device ID instead of repeating the same command to all locks. 